### PR TITLE
refactor/soo-vector-search

### DIFF
--- a/backend/app/agents/meal_planner.py
+++ b/backend/app/agents/meal_planner.py
@@ -239,7 +239,8 @@ class MealPlannerAgent:
             
             # 1단계: 임베딩된 데이터에서 식단표 생성 시도
             print("🔍 1단계: 임베딩된 레시피 데이터에서 식단표 생성 시도")
-            embedded_plan = await self._generate_meal_plan_from_embeddings(days, constraints_text, user_id, fast_mode)
+            embedded_plan = await self._generate_meal_plan_from_embeddings(days, constraints_text, user_id, fast_mode,
+                                                                          allergies=allergies, dislikes=dislikes)
             
             if embedded_plan and len(embedded_plan.get("days", [])) > 0:
                 print(f"✅ 임베딩 데이터로 식단표 생성 성공: {len(embedded_plan['days'])}일")
@@ -251,7 +252,8 @@ class MealPlannerAgent:
             
             # 3단계: AI 구조를 바탕으로 임베딩 데이터에서 구체적 메뉴 검색
             print("🔍 3단계: AI 구조 + 임베딩 데이터로 구체적 메뉴 생성")
-            detailed_plan = await self._generate_detailed_meals_from_embeddings(meal_structure, constraints_text, user_id, fast_mode)
+            detailed_plan = await self._generate_detailed_meals_from_embeddings(meal_structure, constraints_text, user_id, fast_mode,
+                                                                                allergies=allergies, dislikes=dislikes)
             
             if detailed_plan and len(detailed_plan.get("days", [])) > 0:
                 print(f"✅ AI + 임베딩 데이터로 식단표 생성 성공: {len(detailed_plan['days'])}일")
@@ -323,23 +325,27 @@ class MealPlannerAgent:
         return " | ".join(constraints)
     
     async def _search_with_diversity(
-        self, 
-        search_query: str, 
-        constraints: str, 
-        user_id: Optional[str], 
-        used_recipes: set, 
-        max_results: int = 35
+        self,
+        search_query: str,
+        constraints: str,
+        user_id: Optional[str],
+        used_recipes: set,
+        max_results: int = 35,
+        allergies: Optional[List[str]] = None,
+        dislikes: Optional[List[str]] = None
     ) -> List[Dict[str, Any]]:
         """
         다양성을 고려한 레시피 검색 (중복 방지)
-        
+
         Args:
             search_query: 검색 쿼리
             constraints: 제약 조건
             user_id: 사용자 ID
             used_recipes: 이미 사용된 레시피 ID 집합
             max_results: 최대 결과 수
-            
+            allergies: 알레르기 목록 (임시 + 프로필)
+            dislikes: 비선호 목록 (임시 + 프로필)
+
         Returns:
             중복되지 않은 레시피 목록
         """
@@ -348,8 +354,10 @@ class MealPlannerAgent:
             search_results = await hybrid_search_tool.search(
                 query=search_query,
                 profile=constraints,
-                max_results=min(max_results * 2, 10),  # 최대 10개로 제한
-                user_id=user_id
+                max_results=min(max_results * 2, 30),  # 최대 10개로 제한
+                user_id=user_id,
+                allergies=allergies,
+                dislikes=dislikes
             )
             
             if not search_results:
@@ -357,15 +365,27 @@ class MealPlannerAgent:
             
             # 중복되지 않은 레시피만 필터링
             unique_results = []
-            
+
             for result in search_results:
                 recipe_id = result.get('id', '')
+
+                # 디버깅: ID 확인
+                if not recipe_id:
+                    print(f"⚠️ ID 없는 레시피 발견: {result.get('title', 'Unknown')}")
+                    # ID가 없으면 title로 대체
+                    recipe_id = result.get('title', '')
+
                 if recipe_id and recipe_id not in used_recipes:
                     unique_results.append(result)
                     used_recipes.add(recipe_id)  # 중복 방지를 위해 추가
+                    print(f"  ✅ 수집: {result.get('title', 'Unknown')} (ID: {recipe_id})")
                     if len(unique_results) >= max_results:
                         break
-            
+                else:
+                    if recipe_id:
+                        print(f"  ⚠️ 중복 제외: {result.get('title', 'Unknown')} (ID: {recipe_id})")
+
+            print(f"🔍 _search_with_diversity 결과: 검색 {len(search_results)}개 → 중복제거 후 {len(unique_results)}개")
             return unique_results
             
         except Exception as e:
@@ -502,15 +522,18 @@ class MealPlannerAgent:
             "search_priority": ["primary_keywords", "cooking_methods", "secondary_keywords"]
         }
     
-    async def _generate_meal_plan_from_embeddings(self, days: int, constraints: str, user_id: Optional[str] = None, fast_mode: bool = True) -> Optional[Dict[str, Any]]:
+    async def _generate_meal_plan_from_embeddings(self, days: int, constraints: str, user_id: Optional[str] = None, fast_mode: bool = True,
+                                                  allergies: Optional[List[str]] = None, dislikes: Optional[List[str]] = None) -> Optional[Dict[str, Any]]:
         """
         1단계: 임베딩된 레시피 데이터에서 직접 식단표 생성
-        
+
         Args:
             days: 생성할 일수
             constraints: 제약 조건
             user_id: 사용자 ID
-            
+            allergies: 알레르기 목록
+            dislikes: 비선호 목록
+
         Returns:
             생성된 식단표 또는 None
         """
@@ -545,7 +568,8 @@ class MealPlannerAgent:
                 # 기본 키워드로 한 번에 여러 개 검색
                 search_query = f"{' '.join(strategy['primary_keywords'])} 키토"
                 search_results = await self._search_with_diversity(
-                    search_query, constraints, user_id, used_recipes, max_results=days * 3
+                    search_query, constraints, user_id, used_recipes, max_results=days * 3,
+                    allergies=allergies, dislikes=dislikes
                 )
                 
                 if search_results:
@@ -618,15 +642,18 @@ class MealPlannerAgent:
             print(f"❌ 임베딩 데이터 식단표 생성 실패: {e}")
             return None
     
-    async def _generate_detailed_meals_from_embeddings(self, structure: List[Dict[str, str]], constraints: str, user_id: Optional[str] = None, fast_mode: bool = True) -> Optional[Dict[str, Any]]:
+    async def _generate_detailed_meals_from_embeddings(self, structure: List[Dict[str, str]], constraints: str, user_id: Optional[str] = None, fast_mode: bool = True,
+                                                       allergies: Optional[List[str]] = None, dislikes: Optional[List[str]] = None) -> Optional[Dict[str, Any]]:
         """
         3단계: AI 구조를 바탕으로 임베딩 데이터에서 구체적 메뉴 생성
-        
+
         Args:
             structure: AI가 생성한 식단 구조
             constraints: 제약 조건
             user_id: 사용자 ID
-            
+            allergies: 알레르기 목록
+            dislikes: 비선호 목록
+
         Returns:
             생성된 식단표 또는 None
         """
@@ -661,22 +688,14 @@ class MealPlannerAgent:
                     search_query = f"키토 {slot}"
                 
                 search_results = await self._search_with_diversity(
-                    search_query, constraints, user_id, used_recipes, max_results=days_count * 3
+                    search_query, constraints, user_id, used_recipes, max_results=days_count * 3,
+                    allergies=allergies, dislikes=dislikes
                 )
-                
+
                 if search_results:
-                    # 중복 제거하고 필요한 개수만큼 선택
-                    unique_results = []
-                    for result in search_results:
-                        recipe_id = result.get('id', '')
-                        if recipe_id and recipe_id not in used_recipes:
-                            unique_results.append(result)
-                            used_recipes.add(recipe_id)
-                            if len(unique_results) >= days_count:
-                                break
-                    
-                    meal_collections[slot] = unique_results
-                    print(f"✅ {slot} 레시피 {len(unique_results)}개 수집 완료")
+                    # _search_with_diversity에서 이미 중복 제거 완료
+                    meal_collections[slot] = search_results
+                    print(f"✅ {slot} 레시피 {len(search_results)}개 수집 완료")
                 else:
                     meal_collections[slot] = []
                     print(f"❌ {slot} 레시피 검색 실패")

--- a/backend/app/tools/meal/korean_search.py
+++ b/backend/app/tools/meal/korean_search.py
@@ -113,9 +113,11 @@ class KoreanSearchTool:
                                 'id': str(row.get('id', '')),
                                 'title': row.get('title', '제목 없음'),
                                 'content': row.get('content', ''),
+                                'allergens': row.get('allergens', []),
+                                'ingredients': row.get('ingredients', []),
                                 'search_score': row.get('search_score', 1.0),
                                 'search_type': 'ilike_exact',
-                                'metadata': {kk: vv for kk, vv in row.items() if kk not in ['id','title','content','search_score']}
+                                'metadata': {kk: vv for kk, vv in row.items() if kk not in ['id','title','content','search_score','allergens','ingredients']}
                             })
                         return formatted
                 except Exception as e:
@@ -141,9 +143,11 @@ class KoreanSearchTool:
                     'id': str(result.get('id', '')),
                     'title': result.get('title', '제목 없음'),
                     'content': result.get('content', ''),
+                    'allergens': result.get('allergens', []),
+                    'ingredients': result.get('ingredients', []),
                     'search_score': result.get('search_score', 1.0),
                     'search_type': 'pgroonga',
-                    'metadata': {k: v for k, v in result.items() if k not in ['id', 'title', 'content', 'search_score']}
+                    'metadata': {k: v for k, v in result.items() if k not in ['id', 'title', 'content', 'search_score', 'allergens', 'ingredients']}
                 })
 
             return formatted_results
@@ -169,9 +173,11 @@ class KoreanSearchTool:
                     'id': str(result.get('id', '')),
                     'title': result.get('title', '제목 없음'),
                     'content': result.get('content', ''),
+                    'allergens': result.get('allergens', []),
+                    'ingredients': result.get('ingredients', []),
                     'search_score': result.get('search_score', result.get('fts_score', 0.0)),
                     'search_type': 'fts',
-                    'metadata': {k: v for k, v in result.items() if k not in ['id', 'title', 'content', 'fts_score']}
+                    'metadata': {k: v for k, v in result.items() if k not in ['id', 'title', 'content', 'fts_score', 'allergens', 'ingredients']}
                 })
             
             return formatted_results
@@ -198,9 +204,11 @@ class KoreanSearchTool:
                     'id': str(result.get('id', '')),
                     'title': result.get('title', '제목 없음'),
                     'content': result.get('content', ''),
+                    'allergens': result.get('allergens', []),
+                    'ingredients': result.get('ingredients', []),
                     'search_score': result.get('search_score', result.get('similarity_score', 0.0)),
                     'search_type': 'trigram',
-                    'metadata': {k: v for k, v in result.items() if k not in ['id', 'title', 'content', 'similarity_score']}
+                    'metadata': {k: v for k, v in result.items() if k not in ['id', 'title', 'content', 'similarity_score', 'allergens', 'ingredients']}
                 })
             
             return formatted_results
@@ -228,9 +236,11 @@ class KoreanSearchTool:
                     'id': str(result.get('id', '')),
                     'title': result.get('title', '제목 없음'),
                     'content': result.get('content', ''),
+                    'allergens': result.get('allergens', []),
+                    'ingredients': result.get('ingredients', []),
                     'search_score': result.get('search_score', result.get('similarity_score', 0.0)),
                     'search_type': 'vector',
-                    'metadata': {k: v for k, v in result.items() if k not in ['id', 'title', 'content', 'similarity_score']}
+                    'metadata': {k: v for k, v in result.items() if k not in ['id', 'title', 'content', 'similarity_score', 'allergens', 'ingredients']}
                 })
             
             return formatted_results
@@ -278,9 +288,11 @@ class KoreanSearchTool:
                     'id': str(result.get('id', '')),
                     'title': result.get('title', '제목 없음'),
                     'content': result.get('content', ''),
+                    'allergens': result.get('allergens', []),
+                    'ingredients': result.get('ingredients', []),
                     'search_score': 0.5,  # ILIKE 검색 기본 점수
                     'search_type': 'ilike',
-                    'metadata': {k: v for k, v in result.items() if k not in ['id', 'title', 'content']}
+                    'metadata': {k: v for k, v in result.items() if k not in ['id', 'title', 'content', 'allergens', 'ingredients']}
                 })
             
             return formatted_results[:k]
@@ -452,8 +464,11 @@ class KoreanSearchTool:
                         search_message = f"'{meal_hint}' 키워드를 반영해 레시피를 추천했습니다."
                 
                 formatted_results.append({
+                    'id': result.get('id', ''),
                     'title': result.get('title', '제목 없음'),
                     'content': result.get('content', ''),
+                    'allergens': result.get('allergens', []),
+                    'ingredients': result.get('ingredients', []),
                     'similarity': result.get('final_score', 0.0),
                     'metadata': result.get('metadata', {}),
                     'search_types': [result.get('search_type', 'hybrid')],

--- a/backend/app/tools/shared/profile_tool.py
+++ b/backend/app/tools/shared/profile_tool.py
@@ -408,13 +408,21 @@ class UserProfileTool:
         for recipe in recipes:
             # 알레르기 체크
             recipe_allergens = set(recipe.get("allergens", []))
+
+            # 제목(title)에서도 알레르기 검색 (fallback)
+            recipe_title = recipe.get("title", "")
+            for allergy in user_allergies:
+                if allergy in recipe_title:
+                    logger.info(f"🚫 알레르기(제목)로 인해 제외: {recipe_title} - '{allergy}' 포함")
+                    recipe_allergens.add(allergy)
+
             if user_allergies and recipe_allergens.intersection(user_allergies):
                 logger.info(f"🚫 알레르기로 인해 제외: {recipe.get('title', 'Unknown')} - {recipe_allergens.intersection(user_allergies)}")
                 continue
             
             # 비선호 재료 체크
             ingredients_data = recipe.get("ingredients", [])
-            
+
             # ingredients가 문자열인 경우 JSON 파싱
             if isinstance(ingredients_data, str):
                 try:
@@ -423,8 +431,27 @@ class UserProfileTool:
                 except (json.JSONDecodeError, ValueError):
                     logger.warning(f"⚠️ ingredients 파싱 실패: {recipe.get('title', 'Unknown')} - {ingredients_data}")
                     ingredients_data = []
-            
-            recipe_ingredients = set(ingredients_data)
+
+            # ingredients에서 재료명 추출 (딕셔너리 리스트 또는 문자열 리스트 지원)
+            recipe_ingredients = set()
+            if ingredients_data:
+                for item in ingredients_data:
+                    if isinstance(item, dict):
+                        # 딕셔너리 형태: {"name": "토마토", "amount": "2개"}
+                        if "name" in item:
+                            recipe_ingredients.add(item["name"])
+                    elif isinstance(item, str):
+                        # 문자열 리스트: ["토마토", "계란"]
+                        recipe_ingredients.add(item)
+
+            # 제목(title)에서도 비선호 재료 검색 (fallback)
+            recipe_title = recipe.get("title", "")
+            for dislike in user_dislikes:
+                if dislike in recipe_title:
+                    logger.info(f"🚫 비선호 재료(제목)로 인해 제외: {recipe_title} - '{dislike}' 포함")
+                    recipe_ingredients.add(dislike)  # 제목에 있으면 추가
+
+            # 비선호 재료와 교집합 체크
             if user_dislikes and recipe_ingredients.intersection(user_dislikes):
                 logger.info(f"🚫 비선호 재료로 인해 제외: {recipe.get('title', 'Unknown')} - {recipe_ingredients.intersection(user_dislikes)}")
                 continue


### PR DESCRIPTION
## 📋 변경 사항

* [ ] 새로운 기능 추가
* [ ] 버그 수정
* [ ] 문서 업데이트
* [x] 리팩토링
* [ ] 테스트 추가

---

## 🔍 상세 설명


* 검색(벡터서치) 단계에서 **알레르기 / 비선호 재료**를 필터링하도록 리팩토링하여 불필요한 후처리 제거 및 성능 개선
* 사용자 프로필(영구 제약)과 임시 제약조건을 병합해서 검색 시 반영
* 중복 제거 로직 개선(아이디 없는 레시피 대응 및 title 기반 대체)
* 모든 검색결과 포맷에 `allergens`, `ingredients` 필드 명시
* 레시피 제목에서도 알레르기/비선호 감지하여 필터링(fallback)
* 디버깅 로그 추가로 추적 편의성 향상

### 파일별 변경 사항 (요약)

#### `backend/app/agents/meal_planner.py`

* `allergies`, `dislikes` 파라미터를 `_generate_meal_plan_from_embeddings`, `_generate_detailed_meals_from_embeddings`에 추가하여 검색 단계로 전달 (위치: ~242, ~255줄).
* `_search_with_diversity` 개선:

  * `allergies`, `dislikes` 파라미터 수용.
  * 최대 검색 결과 수 10 → 30으로 증가.
  * ID가 없는 레시피는 title로 중복 판별 보완.
  * 수집/중복 제외 등 디버깅 로그, 결과 통계 로그 추가.
* `_generate_detailed_meals_from_embeddings`에서 중복 제거 로직 제거(이미 검색단에서 처리) 및 코드 간소화.

#### `backend/app/tools/meal/korean_search.py`

* 모든 검색 메서드의 결과 포맷 통일: `allergens`, `ingredients` 필드를 명시적으로 추가.

  * 적용 메서드: `_exact_match_ilike`, `_pgroonga_search`, `_fts_search`, `_trigram_search`, `_vector_search`, `_ilike_search`, `korean_hybrid_search` 등.
* metadata 생성 시 `allergens`, `ingredients`를 제외하여 중복 저장 방지.

#### `backend/app/tools/shared/hybrid_search.py`

* `search` 메서드에 `allergies`, `dislikes` 임시 제약조건 파라미터 추가.
* DB 프로필의 알레르기/비선호와 임시 제약조건 병합(중복 제거 후 set 처리). 프로필 조회 실패 시 임시 제약조건만 사용.
* 병합된 제약조건으로 `filter_recipes_by_preferences` 호출하여 검색 결과 필터링.
* 필터링 전/후 결과 개수 디버깅 로그 추가.
* 결과 포맷에 `allergens`, `ingredients` 포함.

#### `backend/app/tools/shared/profile_tool.py`

* 레시피의 `allergens` 필드뿐만 아니라 **레시피 제목(title)** 에서도 알레르기 키워드 탐지 추가 (fallback).
* 비선호 재료 파싱 개선:

  * 딕셔너리 리스트(`{"name": "토마토", "amount": "2개"}`) 및 문자열 리스트(`["토마토","계란"]`) 모두 지원.
  * `name` 키가 있는 경우 재료명만 추출.
* 비선호 재료 필터링 시 `ingredients`와 `title` 모두에서 검사하여 교집합 확인.

---

## 🧪 테스트

* [ ] 기존 테스트 통과
* [ ] 새로운 테스트 추가
* [x] 수동 테스트 완료

**수동 테스트 제안 절차**

1. 프로필에 알레르기 및 비선호 항목(예: `땅콩`, `계란`)을 추가한 사용자로 시나리오 생성
2. 임시 제약조건을 포함/제외한 상태로 벡터 검색 실행
3. 검색결과에서 `allergens`/`ingredients` 필드가 반환되는지 확인
4. 제목에 키워드가 포함된 레시피(예: 제목에 `땅콩` 포함)가 필터링되는지 확인
5. ID가 없는(혹은 ID가 null인) 레시피가 중복으로 들어오는 케이스에서 title기반 중복 제거가 동작하는지 확인
6. 로그(수집/중복 제외/통계)가 예상대로 출력되는지 확인
7. 성능 영향: 벡터검색 결과 수(10→30) 변경에 따른 응답시간 및 메모리 사용량 관찰

---

## 📸 스크린샷 (UI 변경 시)

변경된 UI는 없습니다. (필요 시 결과 JSON 예시 스냅샷 첨부 가능)

---

## 📚 관련 이슈

Closes #issue_number
